### PR TITLE
FIX: make the estimate-bracken action unavailable on OSX

### DIFF
--- a/q2_annotate/kraken2/bracken.py
+++ b/q2_annotate/kraken2/bracken.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 import os
+import platform
 import re
 import subprocess
 import tempfile
@@ -167,6 +168,14 @@ def estimate_bracken(
     level: str = 'S',
     include_unclassified: bool = True
 ) -> (Kraken2ReportDirectoryFormat, pd.DataFrame, pd.DataFrame):
+
+    # Check for macOS and raise an error if detected
+    if platform.system() == "Darwin":
+        raise RuntimeError(
+            "The estimate_bracken action is currently not supported on macOS "
+            "due to the unavailability of the Bracken package. Please try it on Linux."
+        )
+
     _assert_read_lens_available(bracken_db, read_len)
 
     table, reports = _estimate_bracken(

--- a/q2_annotate/kraken2/tests/test_bracken.py
+++ b/q2_annotate/kraken2/tests/test_bracken.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 import os
+import platform
 import shutil
 import tempfile
 import unittest
@@ -204,48 +205,16 @@ class TestBracken(TestPluginBase):
         assert_frame_equal(obs_table, exp_table)
         assert_frame_equal(obs_taxonomy, exp_taxonomy)
         self.assertIsInstance(obs_reports, Kraken2ReportDirectoryFormat)
-    
-    @patch('platform.system', return_value='Darwin')
-    def test_estimate_bracken_osx(self, mock_platform):
-        with self.assertRaisesRegex(
-            RuntimeError, 
-            "The estimate_bracken action is currently not supported on macOS"
-            ):
-            estimate_bracken(
-                kraken_reports=MagicMock(),
-                bracken_db=MagicMock(),
-            )
   
-    @patch('platform.system', return_value='Linux')
-    @patch('q2_annotate.kraken2.bracken._run_bracken_one_sample')
-    def test_estimate_bracken_linux(self, p1, p2):
+    def test_estimate_bracken_linux_vs_osx(self):
+        from qiime2.plugins import annotate
         try:
-            kraken_reports = Kraken2ReportDirectoryFormat(
-                self.get_data_path('reports-mags'), 'r'
-            )
-            bracken_db = BrackenDBDirectoryFormat()
-
-            tables = [
-                pd.read_csv(
-                    self.get_data_path('bracken-report/sample1.table.csv'),
-                    index_col=0
-                ),
-                pd.read_csv(
-                    self.get_data_path('bracken-report/sample2.table.csv'),
-                    index_col=0
-                )
-            ]
-            p1.side_effect = tables
-
-            _estimate_bracken(
-                kraken_reports=kraken_reports,
-                bracken_db=bracken_db,
-                threshold=self.kwargs['threshold'],
-                read_len=self.kwargs['read_len'],
-                level=self.kwargs['level'],
-            )
-        except RuntimeError:
-            self.fail("evaluate_busco raised RuntimeError unexpectedly on Linux")
+            annotate.methods.estimate_bracken
+        except AttributeError:
+            if platform.system() == "Darwin":
+                pass
+            else:
+                raise
 
 
 if __name__ == "__main__":

--- a/q2_annotate/kraken2/tests/test_bracken.py
+++ b/q2_annotate/kraken2/tests/test_bracken.py
@@ -11,7 +11,7 @@ import shutil
 import tempfile
 import unittest
 from subprocess import CalledProcessError
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pandas as pd
 from pandas._testing import assert_frame_equal
@@ -205,7 +205,7 @@ class TestBracken(TestPluginBase):
         assert_frame_equal(obs_table, exp_table)
         assert_frame_equal(obs_taxonomy, exp_taxonomy)
         self.assertIsInstance(obs_reports, Kraken2ReportDirectoryFormat)
-  
+
     def test_estimate_bracken_linux_vs_osx(self):
         from qiime2.plugins import annotate
         try:

--- a/q2_annotate/plugin_setup.py
+++ b/q2_annotate/plugin_setup.py
@@ -309,10 +309,10 @@ if platform.system() != "Darwin":
         },
         parameter_descriptions={
             'threshold': 'Bracken: number of reads required PRIOR to abundance '
-                        'estimation to perform re-estimation.',
+                         'estimation to perform re-estimation.',
             'read_len': ('Bracken: read length to get all classifications for. '
-                        'For paired end data (e.g., 2x150) this should be set '
-                        'to the length of the single-end reads (e.g., 150).'),
+                         'For paired end data (e.g., 2x150) this should be set '
+                         'to the length of the single-end reads (e.g., 150).'),
             'level': 'Bracken: taxonomic level to estimate abundance at.',
             'include_unclassified': 'Bracken does not include the unclassified '
                                     'read counts in the feature table. Set this '

--- a/q2_annotate/plugin_setup.py
+++ b/q2_annotate/plugin_setup.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 import importlib
+import platform
 
 from q2_quality_control.plugin_setup import (
     filter_parameters, filter_parameter_descriptions
@@ -284,46 +285,47 @@ plugin.methods.register_function(
     description="Collates kraken2 outputs"
 )
 
-plugin.methods.register_function(
-    function=q2_annotate.kraken2.bracken.estimate_bracken,
-    inputs={
-        "kraken_reports": SampleData[Kraken2Reports % Properties('reads')],
-        "bracken_db": BrackenDB
-    },
-    parameters={
-        'threshold': Int % Range(0, None),
-        'read_len': Int % Range(0, None),
-        'level': Str % Choices(['D', 'P', 'C', 'O', 'F', 'G', 'S']),
-        'include_unclassified': Bool
-    },
-    outputs=[
-        ('reports', SampleData[Kraken2Reports % Properties('bracken')]),
-        ('taxonomy', FeatureData[Taxonomy]),
-        ('table', FeatureTable[Frequency])
-    ],
-    input_descriptions={
-        "kraken_reports": "Reports produced by Kraken2.",
-        "bracken_db": "Bracken database."
-    },
-    parameter_descriptions={
-        'threshold': 'Bracken: number of reads required PRIOR to abundance '
-                     'estimation to perform re-estimation.',
-        'read_len': ('Bracken: read length to get all classifications for. '
-                     'For paired end data (e.g., 2x150) this should be set '
-                     'to the length of the single-end reads (e.g., 150).'),
-        'level': 'Bracken: taxonomic level to estimate abundance at.',
-        'include_unclassified': 'Bracken does not include the unclassified '
-                                'read counts in the feature table. Set this '
-                                'to True to include those regardless.'
-    },
-    output_descriptions={
-        'reports': 'Reports modified by Bracken.',
-    },
-    name='Perform read abundance re-estimation using Bracken.',
-    description='This method uses Bracken to re-estimate read abundances. '
-                'Only available on Linux platforms.',
-    citations=[citations["wood2019"]]
-)
+if platform.system() != "Darwin":
+    plugin.methods.register_function(
+        function=q2_annotate.kraken2.bracken.estimate_bracken,
+        inputs={
+            "kraken_reports": SampleData[Kraken2Reports % Properties('reads')],
+            "bracken_db": BrackenDB
+        },
+        parameters={
+            'threshold': Int % Range(0, None),
+            'read_len': Int % Range(0, None),
+            'level': Str % Choices(['D', 'P', 'C', 'O', 'F', 'G', 'S']),
+            'include_unclassified': Bool
+        },
+        outputs=[
+            ('reports', SampleData[Kraken2Reports % Properties('bracken')]),
+            ('taxonomy', FeatureData[Taxonomy]),
+            ('table', FeatureTable[Frequency])
+        ],
+        input_descriptions={
+            "kraken_reports": "Reports produced by Kraken2.",
+            "bracken_db": "Bracken database."
+        },
+        parameter_descriptions={
+            'threshold': 'Bracken: number of reads required PRIOR to abundance '
+                        'estimation to perform re-estimation.',
+            'read_len': ('Bracken: read length to get all classifications for. '
+                        'For paired end data (e.g., 2x150) this should be set '
+                        'to the length of the single-end reads (e.g., 150).'),
+            'level': 'Bracken: taxonomic level to estimate abundance at.',
+            'include_unclassified': 'Bracken does not include the unclassified '
+                                    'read counts in the feature table. Set this '
+                                    'to True to include those regardless.'
+        },
+        output_descriptions={
+            'reports': 'Reports modified by Bracken.',
+        },
+        name='Perform read abundance re-estimation using Bracken.',
+        description='This method uses Bracken to re-estimate read abundances. '
+                    'Only available on Linux platforms.',
+        citations=[citations["wood2019"]]
+    )
 
 plugin.methods.register_function(
     function=q2_annotate.kraken2.build_kraken_db,

--- a/q2_annotate/plugin_setup.py
+++ b/q2_annotate/plugin_setup.py
@@ -320,7 +320,8 @@ plugin.methods.register_function(
         'reports': 'Reports modified by Bracken.',
     },
     name='Perform read abundance re-estimation using Bracken.',
-    description='This method uses Bracken to re-estimate read abundances.',
+    description='This method uses Bracken to re-estimate read abundances. '
+                'Only available on Linux platforms.',
     citations=[citations["wood2019"]]
 )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
This PR removes the `estimate-bracken` action registration from plugin_setup.py in case the detected OS is OSX. The reason for this behaviour is the unavailability of Bracken on OSX platform - we don't want the users to run into weird erros.

More details in [this](https://forum.qiime2.org/t/bracken-command-not-found/32164/12) forum post.