### PR TITLE
ENH: add ability to fetch gtdb to build_kraken_db

### DIFF
--- a/q2_annotate/kraken2/database.py
+++ b/q2_annotate/kraken2/database.py
@@ -43,6 +43,7 @@ COLLECTIONS = {
     "eupathdb": "eupathdb48",
     "nt": "nt",
     "corent": "core_nt",
+    "gtdb": "gtdb_genome_reps",
     "greengenes": "Greengenes13.5",
     "rdp": "RDP11.5",
     "silva132": "Silva132",

--- a/q2_annotate/plugin_setup.py
+++ b/q2_annotate/plugin_setup.py
@@ -336,8 +336,8 @@ plugin.methods.register_function(
         'collection': Str % Choices(
             ['viral', 'minusb', 'standard', 'standard8', 'standard16',
              'pluspf', 'pluspf8', 'pluspf16', 'pluspfp', 'pluspfp8',
-             'pluspfp16', 'eupathdb', 'nt', 'corent', 'greengenes',
-             'rdp', 'silva132', 'silva138'],
+             'pluspfp16', 'eupathdb', 'nt', 'corent', 'gtdb',
+             'greengenes', 'rdp', 'silva132', 'silva138'],
         ),
         'threads': Int % Range(1, None),
         'kmer_len': Int % Range(1, None),


### PR DESCRIPTION
Adds ability to fetch the [GTDB (genomic_files_reps)](https://benlangmead.github.io/aws-indexes/k2) Kraken2 database.