### PR TITLE
Filter pangenome

### DIFF
--- a/q2_annotate/filtering/__init__.py
+++ b/q2_annotate/filtering/__init__.py
@@ -7,6 +7,11 @@
 # ----------------------------------------------------------------------------
 
 from .filter_mags import filter_derep_mags, filter_mags
-from .filter_pangenome import filter_reads_pangenome
+from .filter_pangenome import filter_reads_pangenome, construct_pangenome_index
 
-__all__ = ["filter_derep_mags", "filter_mags", "filter_reads_pangenome"]
+__all__ = [
+    "filter_derep_mags",
+    "filter_mags",
+    "filter_reads_pangenome",
+    "construct_pangenome_index"
+]

--- a/q2_annotate/filtering/filter_pangenome.py
+++ b/q2_annotate/filtering/filter_pangenome.py
@@ -173,13 +173,13 @@ def filter_reads_pangenome(
     construct_index = ctx.get_action("annotate", "construct_pangenome_index")
 
     if index is None:
+        print("Reference index was not provided - it will be generated.")
         index, = construct_index(n_threads)
 
     print("Filtering reads against the index...")
     filter_params = {
         k: v for k, v in locals().items() if k in
-        ['n_threads', 'mode', 'ref_gap_open_penalty',
-         'ref_gap_ext_penalty']
+        ['n_threads', 'mode', 'ref_gap_open_penalty', 'ref_gap_ext_penalty']
     }
     filtered_reads, = filter_reads(
         demultiplexed_sequences=reads,

--- a/q2_annotate/filtering/filter_pangenome.py
+++ b/q2_annotate/filtering/filter_pangenome.py
@@ -79,7 +79,7 @@ def _fetch_and_extract_grch38(get_ncbi_genomes: callable, dest_dir: str):
         dest_dir (str): The directory where the genome data will be saved.
     """
     results = get_ncbi_genomes(
-        taxon='Homo sapiens',
+        taxa=['Homo sapiens'],
         only_reference=True,
         assembly_levels=['chromosome'],
         assembly_source='refseq',
@@ -118,6 +118,42 @@ def _combine_fasta_files(*fasta_in_fp, fasta_out_fp):
             os.remove(f_in)
 
 
+def construct_pangenome_index(ctx, n_threads=1):
+    """Constructs the pangenome index.
+
+    This action will fetch the human pangenome and GRCh38 reference genome,
+    combine them into a single FASTA file, and generate a Bowtie 2 index.
+    """
+    get_ncbi_genomes = ctx.get_action("rescript", "get_ncbi_genomes")
+    build_index = ctx.get_action("quality_control", "bowtie2_build")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        print("Fetching the human pangenome GFA file...")
+        _fetch_and_extract_pangenome(EBI_SERVER_URL, tmp)
+
+        print("Fetching the human GRCh38 reference genome...")
+        _fetch_and_extract_grch38(get_ncbi_genomes, tmp)
+
+        print("Converting pangenome GFA to FASTA...")
+        gfa_fp = glob.glob(os.path.join(tmp, "*.gfa"))[0]
+        pan_fasta_fp = os.path.join(tmp, "pangenome.fasta")
+        _extract_fasta_from_gfa(gfa_fp, pan_fasta_fp)
+
+        print("Generating an index of the combined reference...")
+        combined_fasta_fp = os.path.join(tmp, "combined.fasta")
+        _combine_fasta_files(
+            pan_fasta_fp, os.path.join(tmp, "grch38.fasta"),
+            fasta_out_fp=combined_fasta_fp
+        )
+        combined_reference = ctx.make_artifact(
+            "FeatureData[Sequence]", combined_fasta_fp
+        )
+        index, = build_index(
+            sequences=combined_reference, n_threads=n_threads
+        )
+    return index
+
+
 def filter_reads_pangenome(
         ctx, reads, index=None, n_threads=1, mode='local',
         sensitivity='sensitive', ref_gap_open_penalty=5,
@@ -132,48 +168,24 @@ def filter_reads_pangenome(
     generates a Bowtie 2 index if not already provided. It then filters
     reads against this index according to the specified sensitivity.
     """
-    get_ncbi_genomes = ctx.get_action("rescript", "get_ncbi_genomes")
-    build_index = ctx.get_action("quality_control", "bowtie2_build")
+
     filter_reads = ctx.get_action("quality_control", "filter_reads")
+    construct_index = ctx.get_action("annotate", "construct_pangenome_index")
 
-    with tempfile.TemporaryDirectory() as tmp:
-        if index is None:
-            print("Reference index was not provided - it will be generated.")
-            print("Fetching the human pangenome GFA file...")
-            _fetch_and_extract_pangenome(EBI_SERVER_URL, tmp)
+    if index is None:
+        index, = construct_index(n_threads)
 
-            print("Fetching the human GRCh38 reference genome...")
-            _fetch_and_extract_grch38(get_ncbi_genomes, tmp)
-
-            print("Converting pangenome GFA to FASTA...")
-            gfa_fp = glob.glob(os.path.join(tmp, "*.gfa"))[0]
-            pan_fasta_fp = os.path.join(tmp, "pangenome.fasta")
-            _extract_fasta_from_gfa(gfa_fp, pan_fasta_fp)
-
-            print("Generating an index of the combined reference...")
-            combined_fasta_fp = os.path.join(tmp, "combined.fasta")
-            _combine_fasta_files(
-                pan_fasta_fp, os.path.join(tmp, "grch38.fasta"),
-                fasta_out_fp=combined_fasta_fp
-            )
-            combined_reference = ctx.make_artifact(
-                "FeatureData[Sequence]", combined_fasta_fp
-            )
-            index, = build_index(
-                sequences=combined_reference, n_threads=n_threads
-            )
-
-        print("Filtering reads against the index...")
-        filter_params = {
-            k: v for k, v in locals().items() if k in
-            ['n_threads', 'mode', 'ref_gap_open_penalty',
-             'ref_gap_ext_penalty']
-        }
-        filtered_reads, = filter_reads(
-            demultiplexed_sequences=reads,
-            database=index,
-            exclude_seqs=True,
-            **filter_params
-        )
+    print("Filtering reads against the index...")
+    filter_params = {
+        k: v for k, v in locals().items() if k in
+        ['n_threads', 'mode', 'ref_gap_open_penalty',
+         'ref_gap_ext_penalty']
+    }
+    filtered_reads, = filter_reads(
+        demultiplexed_sequences=reads,
+        database=index,
+        exclude_seqs=True,
+        **filter_params
+    )
 
     return filtered_reads, index

--- a/q2_annotate/filtering/tests/test_filter.py
+++ b/q2_annotate/filtering/tests/test_filter.py
@@ -18,7 +18,7 @@ import qiime2
 from q2_annotate.filtering.filter_pangenome import (
     _fetch_and_extract_grch38, _extract_fasta_from_gfa,
     _fetch_and_extract_pangenome, filter_reads_pangenome,
-    _combine_fasta_files, EBI_SERVER_URL
+    _combine_fasta_files, EBI_SERVER_URL, construct_pangenome_index
 )
 from qiime2.plugin.testing import TestPluginBase
 
@@ -184,7 +184,7 @@ class TestMAGFiltering(TestPluginBase):
         _fetch_and_extract_grch38(fake_callable, "/some/where")
 
         fake_callable.assert_called_once_with(
-            taxon='Homo sapiens',
+            taxa=['Homo sapiens'],
             only_reference=True,
             assembly_levels=['chromosome'],
             assembly_source='refseq',
@@ -287,7 +287,7 @@ class TestMAGFiltering(TestPluginBase):
     )
     @patch('q2_annotate.filtering.filter_pangenome._fetch_and_extract_grch38')
     @patch('q2_annotate.filtering.filter_pangenome._extract_fasta_from_gfa')
-    def test_filter_reads_pangenome(
+    def test_construct_pangenome_index(
             self, mock_extract_fasta, mock_fetch_grch38, mock_fetch_pangenome
     ):
         # we don't use the temp_dir from the test class as its content
@@ -304,14 +304,8 @@ class TestMAGFiltering(TestPluginBase):
         ctx.get_action(
             "quality_control", "bowtie2_build"
         ).return_value = (mock_build_index_result,)
-
-        mock_filtered_reads_result = MagicMock()
-        ctx.get_action(
-            "quality_control", "filter_reads"
-        ).return_value = (mock_filtered_reads_result,)
         ctx.make_artifact.return_value = MagicMock()
 
-        reads = MagicMock()
 
         # prepare some files which will be used by _combined_fasta_files
         open(os.path.join(temp_dir, "pangenome.gfa"), 'w').close()
@@ -328,17 +322,11 @@ class TestMAGFiltering(TestPluginBase):
                    return_value=MagicMock(name='TemporaryDirectory',
                                           __enter__=lambda x: temp_dir,
                                           __exit__=lambda x, y, z, w: None)):
-            filtered_reads, generated_index = filter_reads_pangenome(
-                ctx=ctx,
-                reads=reads,
-                index=None,
-                n_threads=1
-            )
+            generated_index = construct_pangenome_index(ctx=ctx, n_threads=1)
 
             # Assertions
             ctx.get_action.assert_any_call("rescript", "get_ncbi_genomes")
             ctx.get_action.assert_any_call("quality_control", "bowtie2_build")
-            ctx.get_action.assert_any_call("quality_control", "filter_reads")
 
             mock_fetch_pangenome.assert_called_once_with(
                 EBI_SERVER_URL, temp_dir
@@ -368,21 +356,51 @@ class TestMAGFiltering(TestPluginBase):
             ).assert_has_calls(
                 [call(sequences=ANY, n_threads=1)], any_order=True
             )
-            ctx.get_action(
-                'quality_control', 'filter_reads'
-            ).assert_has_calls([call(
-                    demultiplexed_sequences=reads,
-                    database=generated_index,
-                    exclude_seqs=True,
-                    n_threads=1,
-                    mode='local',
-                    ref_gap_open_penalty=5,
-                    ref_gap_ext_penalty=3
-                )], any_order=True)
+
             self.assertIsNotNone(generated_index)
 
         # clean up
         shutil.rmtree(temp_dir)
+
+    def test_filter_reads_pangenome(self):
+        # we construct our own context so that we can control each "action"
+        # being retrieved from it
+        ctx = MagicMock()
+        ctx.get_action.return_value = MagicMock()
+        mock_filtered_reads_result = MagicMock()
+        ctx.get_action(
+            "quality_control", "filter_reads"
+        ).return_value = (mock_filtered_reads_result,)
+        mock_index = MagicMock()
+        ctx.get_action(
+            "annotate", "construct_pangenome_index"
+        ).return_value = (mock_index,)
+
+        reads = MagicMock()
+
+        filtered_reads, generated_index = filter_reads_pangenome(
+            ctx=ctx,
+            reads=reads,
+            index=None,
+            n_threads=1
+        )
+
+        # Assertions
+        ctx.get_action.assert_any_call("annotate", "construct_pangenome_index")
+        ctx.get_action.assert_any_call("quality_control", "filter_reads")
+
+        ctx.get_action(
+            'quality_control', 'filter_reads'
+        ).assert_has_calls([call(
+            demultiplexed_sequences=reads,
+            database=generated_index,
+            exclude_seqs=True,
+            n_threads=1,
+            mode='local',
+            ref_gap_open_penalty=5,
+            ref_gap_ext_penalty=3
+        )], any_order=True)
+        self.assertIsNotNone(generated_index)
 
 
 if __name__ == "__main__":

--- a/q2_annotate/plugin_setup.py
+++ b/q2_annotate/plugin_setup.py
@@ -35,7 +35,7 @@ from q2_types.per_sample_sequences import (
 from q2_types.sample_data import SampleData
 from q2_types.feature_map import FeatureMap, MAGtoContigs
 from qiime2.core.type import (
-    Bool, Range, Int, Str, Float, List, Choices, Visualization, TypeMatch
+    Bool, Range, Int, Str, Float, List, Choices, Visualization, TypeMatch, Threads
 )
 from qiime2.core.type import (Properties, TypeMap)
 from qiime2.plugin import (Plugin, Citations)
@@ -1545,6 +1545,22 @@ I_reads, O_reads = TypeMap({
     SampleData[PairedEndSequencesWithQuality]:
         SampleData[PairedEndSequencesWithQuality],
 })
+
+plugin.pipelines.register_function(
+    function=q2_annotate.filtering.construct_pangenome_index,
+    inputs={},
+    parameters={"n_threads": Threads},
+    outputs=[("index", Bowtie2Index)],
+    input_descriptions={},
+    parameter_descriptions={
+        "n_threads": "Number of threads to use when building the index."
+    },
+    output_descriptions={"index": "Generated combined human reference index."},
+    name="Construct a human pangenome index.",
+    description="This method generates a Bowtie2 index fo the combined human "
+                "GRCh38 reference genome and the draft human pangenome.",
+    citations=[],
+)
 
 plugin.pipelines.register_function(
     function=q2_annotate.filtering.filter_reads_pangenome,


### PR DESCRIPTION
Closes #250.

Additionally, this PR updates the filtering action to be in line with the recent changes to the `get-ncbi-genomes` in RESCRIPT (see below).

Depends on https://github.com/bokulich-lab/RESCRIPt/pull/218. 