### PR TITLE
FIX: classify-kraken2 fails when trying to process empty fastq files (Issue #211)

### DIFF
--- a/q2_annotate/kraken2/classification.py
+++ b/q2_annotate/kraken2/classification.py
@@ -198,8 +198,9 @@ def classify_kraken2_helper(
             # check for empty fastq file
             try:
                 for f in fps:
-                    pd.read_csv(f,compression='gzip')
-            except pd.errors.EmptyDataError:
+                    #empty gzipped files have a size of 20 bytes
+                    assert os.path.getsize(f)>20
+            except AssertionError:
                 print(f"At least one of the files for sample {_sample} is empty. Classification will not be run on this sample.")
                 with open(report_fp,'a') as f:
                     print("0.0\t0\t0\tUnclassified\t0\tUnclassified",file=f)

--- a/q2_annotate/kraken2/classification.py
+++ b/q2_annotate/kraken2/classification.py
@@ -194,6 +194,18 @@ def classify_kraken2_helper(
             output_fp, report_fp = _construct_output_paths(
                 _sample, kraken2_outputs_dir, kraken2_reports_dir
             )
+
+            try:
+                for f in fps:
+                    pd.read_csv(f,compression='gzip')
+            except pd.errors.EmptyDataError:
+                print(f"At least one of the files for sample {_sample} is empty. Classification will not be run on this sample.")
+                with open(f"{kraken2_reports_dir}/{_sample}.report.txt",'a') as f:
+                    print("0.0\t0\t0\tUnclassified\t0\tUnclassified",file=f)
+                with open(f"{kraken2_outputs_dir}/{_sample}.output.txt",'a') as f:
+                    print("U\t0\tNo_sequence\tUnclassified\tNone",file=f)
+                continue
+
             cmd = deepcopy(base_cmd)
             cmd.extend(
                 ["--report", report_fp, "--output", output_fp, *fps]

--- a/q2_annotate/kraken2/classification.py
+++ b/q2_annotate/kraken2/classification.py
@@ -195,14 +195,15 @@ def classify_kraken2_helper(
                 _sample, kraken2_outputs_dir, kraken2_reports_dir
             )
 
+            # check for empty fastq file
             try:
                 for f in fps:
                     pd.read_csv(f,compression='gzip')
             except pd.errors.EmptyDataError:
                 print(f"At least one of the files for sample {_sample} is empty. Classification will not be run on this sample.")
-                with open(f"{kraken2_reports_dir}/{_sample}.report.txt",'a') as f:
+                with open(report_fp,'a') as f:
                     print("0.0\t0\t0\tUnclassified\t0\tUnclassified",file=f)
-                with open(f"{kraken2_outputs_dir}/{_sample}.output.txt",'a') as f:
+                with open(output_fp,'a') as f:
                     print("U\t0\tNo_sequence\tUnclassified\tNone",file=f)
                 continue
 

--- a/q2_annotate/kraken2/classification.py
+++ b/q2_annotate/kraken2/classification.py
@@ -204,7 +204,7 @@ def classify_kraken2_helper(
                 with open(report_fp,'a') as f:
                     print("0.0\t0\t0\tUnclassified\t0\tUnclassified",file=f)
                 with open(output_fp,'a') as f:
-                    print("U\t0\tNo_sequence\tUnclassified\tNone",file=f)
+                    print("U\tNo_sequence\t0\t0\tNone",file=f)
                 continue
 
             cmd = deepcopy(base_cmd)


### PR DESCRIPTION
As reported in issue #211, `moshpit classify-kraken2` fails when there are empty fastq files. I added a check within the classify_kraken2_helper function for empty fastq files. If an empty file is encountered, the sample will be skipped and analysis will continue as normal with the remaining samples. When a sample is skipped, a warning message with the sample name will be output to the console and dummy report/output files will be created.

Note: In the issue, it was mentioned that the expected behavior was that "the empty files would be logged to a file". The current version of this check outputs the skipped files to the console, not a log file.