### PR TITLE
ENH: add validation that a lineage dataset or auto lineage is specified

### DIFF
--- a/q2_annotate/busco/busco.py
+++ b/q2_annotate/busco/busco.py
@@ -24,7 +24,7 @@ from q2_annotate.busco.utils import (
     _parse_busco_params, _collect_summaries, _rename_columns,
     _parse_df_columns, _partition_dataframe, _calculate_summary_stats,
     _get_feature_table, _cleanup_bootstrap, _get_mag_lengths,
-    _validate_lineage_dataset_input
+    _validate_lineage_dataset_input, _validate_parameters
 )
 from q2_annotate._utils import _process_common_input_params, run_command
 from q2_types.per_sample_sequences import MultiMAGSequencesDirFmt
@@ -282,6 +282,8 @@ def evaluate_busco(
     scaffold_composition=False,
     num_partitions=None
 ):
+    _validate_parameters(lineage_dataset, auto_lineage, 
+                         auto_lineage_euk, auto_lineage_prok)
 
     kwargs = {
         k: v for k, v in locals().items()

--- a/q2_annotate/busco/busco.py
+++ b/q2_annotate/busco/busco.py
@@ -282,7 +282,7 @@ def evaluate_busco(
     scaffold_composition=False,
     num_partitions=None
 ):
-    _validate_parameters(lineage_dataset, auto_lineage, 
+    _validate_parameters(lineage_dataset, auto_lineage,
                          auto_lineage_euk, auto_lineage_prok)
 
     kwargs = {

--- a/q2_annotate/busco/tests/test_busco_feature_data.py
+++ b/q2_annotate/busco/tests/test_busco_feature_data.py
@@ -123,7 +123,8 @@ class TestBUSCOFeatureData(TestPluginBase):
         mock_clean.assert_called_with(self.temp_dir.name)
 
     # TODO: maybe this could be turned into an actual test
-    def test_evaluate_busco_action(self):
+    @patch('q2_annotate.busco.busco._validate_parameters')
+    def test_evaluate_busco_action(self, mock_validate):
         mock_action = MagicMock(side_effect=[
             lambda x, **kwargs: (0, ),
             lambda x: ("collated_result", ),

--- a/q2_annotate/busco/tests/test_busco_sample_data.py
+++ b/q2_annotate/busco/tests/test_busco_sample_data.py
@@ -189,7 +189,8 @@ class TestBUSCOSampleData(TestPluginBase):
         mock_clean.assert_called_with(self.temp_dir.name)
 
     # TODO: maybe this could be turned into an actual test
-    def test_evaluate_busco_action(self):
+    @patch('q2_annotate.busco.busco._validate_parameters')
+    def test_evaluate_busco_action(self, mock_validate):
         mock_action = MagicMock(side_effect=[
             lambda x, **kwargs: (0, ),
             lambda x: ("collated_result", ),

--- a/q2_annotate/busco/tests/test_utils.py
+++ b/q2_annotate/busco/tests/test_utils.py
@@ -366,6 +366,12 @@ class TestBUSCOUtils(TestPluginBase):
             }
         )
 
-    def test_validate_parameters(self):
+    def test_validate_parameters_lineage_all_false(self):
         with self.assertRaisesRegex(ValueError, "At least one of these parameters"):
-            _validate_parameters(None, None, None, None)
+            _validate_parameters(None, False, False, False)
+    
+    def test_validate_parameters_lineage_and_auto(self):
+        with self.assertRaisesRegex(ValueError, "If 'lineage-dataset' is provided"):
+            _validate_parameters(True, False, True, False)
+            _validate_parameters(True, True, False, False)
+            _validate_parameters(True, False, False, True)

--- a/q2_annotate/busco/tests/test_utils.py
+++ b/q2_annotate/busco/tests/test_utils.py
@@ -373,5 +373,7 @@ class TestBUSCOUtils(TestPluginBase):
     def test_validate_parameters_lineage_and_auto(self):
         with self.assertRaisesRegex(ValueError, "If 'lineage-dataset' is provided"):
             _validate_parameters(True, False, True, False)
+        with self.assertRaisesRegex(ValueError, "If 'lineage-dataset' is provided"):
             _validate_parameters(True, True, False, False)
+        with self.assertRaisesRegex(ValueError, "If 'lineage-dataset' is provided"):
             _validate_parameters(True, False, False, True)

--- a/q2_annotate/busco/tests/test_utils.py
+++ b/q2_annotate/busco/tests/test_utils.py
@@ -369,7 +369,7 @@ class TestBUSCOUtils(TestPluginBase):
     def test_validate_parameters_lineage_all_false(self):
         with self.assertRaisesRegex(ValueError, "At least one of these parameters"):
             _validate_parameters(None, False, False, False)
-    
+
     def test_validate_parameters_lineage_and_auto(self):
         with self.assertRaisesRegex(ValueError, "If 'lineage-dataset' is provided"):
             _validate_parameters(True, False, True, False)

--- a/q2_annotate/busco/tests/test_utils.py
+++ b/q2_annotate/busco/tests/test_utils.py
@@ -12,7 +12,7 @@ from qiime2.plugin.testing import TestPluginBase
 from q2_annotate.busco.utils import (
     _parse_busco_params, _collect_summaries, _parse_df_columns,
     _partition_dataframe, _get_feature_table, _calculate_summary_stats,
-    _get_mag_lengths, _validate_lineage_dataset_input
+    _get_mag_lengths, _validate_lineage_dataset_input, _validate_parameters
 )
 from q2_types.per_sample_sequences import MultiMAGSequencesDirFmt
 from q2_types.feature_data_mag import MAGSequencesDirFmt
@@ -365,3 +365,7 @@ class TestBUSCOUtils(TestPluginBase):
                 "auto_lineage_prok": False
             }
         )
+
+    def test_validate_parameters(self):
+        with self.assertRaisesRegex(ValueError, "At least one of these parameters"):
+            _validate_parameters(None, None, None, None)

--- a/q2_annotate/busco/utils.py
+++ b/q2_annotate/busco/utils.py
@@ -272,9 +272,14 @@ def _get_mag_lengths(bins: Union[MultiMAGSequencesDirFmt, MAGSequencesDirFmt]):
 
 def _validate_parameters(lineage_dataset, auto_lineage,
                          auto_lineage_euk, auto_lineage_prok):
-    if all(value is None for value in locals().values()):
+    if not any([lineage_dataset, auto_lineage, auto_lineage_euk, auto_lineage_prok]):
         raise ValueError(
             "At least one of these parameters must be provided/set to True: "
             "'lineage-dataset', 'auto-lineage', 'auto-lineage_euk', "
             "'auto_lineage-prok'."
+        )
+    if lineage_dataset and any([auto_lineage, auto_lineage_euk, auto_lineage_prok]):
+        raise ValueError(
+            "If 'lineage-dataset' is provided, all the parameters 'auto-lineage', "
+            "'auto-lineage_euk' and 'auto_lineage-prok' must be set to False."
         )

--- a/q2_annotate/busco/utils.py
+++ b/q2_annotate/busco/utils.py
@@ -275,11 +275,11 @@ def _validate_parameters(lineage_dataset, auto_lineage,
     if not any([lineage_dataset, auto_lineage, auto_lineage_euk, auto_lineage_prok]):
         raise ValueError(
             "At least one of these parameters must be provided/set to True: "
-            "'lineage-dataset', 'auto-lineage', 'auto-lineage_euk', "
-            "'auto_lineage-prok'."
+            "'lineage-dataset', 'auto-lineage', 'auto-lineage-euk', "
+            "'auto-lineage-prok'."
         )
     if lineage_dataset and any([auto_lineage, auto_lineage_euk, auto_lineage_prok]):
         raise ValueError(
             "If 'lineage-dataset' is provided, all the parameters 'auto-lineage', "
-            "'auto-lineage_euk' and 'auto_lineage-prok' must be set to False."
+            "'auto-lineage-euk' and 'auto-lineage-prok' must be set to False."
         )

--- a/q2_annotate/busco/utils.py
+++ b/q2_annotate/busco/utils.py
@@ -269,7 +269,8 @@ def _get_mag_lengths(bins: Union[MultiMAGSequencesDirFmt, MAGSequencesDirFmt]):
             lengths[mag_id] = sum([len(s) for s in seq])
         return pd.Series(lengths, name="length")
 
-def _validate_parameters(lineage_dataset, auto_lineage, 
+
+def _validate_parameters(lineage_dataset, auto_lineage,
                          auto_lineage_euk, auto_lineage_prok):
     if all(value is None for value in locals().values()):
         raise ValueError(

--- a/q2_annotate/busco/utils.py
+++ b/q2_annotate/busco/utils.py
@@ -269,10 +269,11 @@ def _get_mag_lengths(bins: Union[MultiMAGSequencesDirFmt, MAGSequencesDirFmt]):
             lengths[mag_id] = sum([len(s) for s in seq])
         return pd.Series(lengths, name="length")
 
-def _validate_parameters(lineage_dataset, auto_lineage, auto_lineage_euk, auto_lineage_prok):
+def _validate_parameters(lineage_dataset, auto_lineage, 
+                         auto_lineage_euk, auto_lineage_prok):
     if all(value is None for value in locals().values()):
         raise ValueError(
-            "At least one of these parameters must be provided: "
-            "`lineage-dataset`, `auto-lineage`, `auto-lineage_euk`, "
-            "`auto_lineage-prok`."
+            "At least one of these parameters must be provided/set to True: "
+            "'lineage-dataset', 'auto-lineage', 'auto-lineage_euk', "
+            "'auto_lineage-prok'."
         )

--- a/q2_annotate/busco/utils.py
+++ b/q2_annotate/busco/utils.py
@@ -268,3 +268,11 @@ def _get_mag_lengths(bins: Union[MultiMAGSequencesDirFmt, MAGSequencesDirFmt]):
             seq = skbio.io.read(mag_fp, format="fasta")
             lengths[mag_id] = sum([len(s) for s in seq])
         return pd.Series(lengths, name="length")
+
+def _validate_parameters(lineage_dataset, auto_lineage, auto_lineage_euk, auto_lineage_prok):
+    if all(value is None for value in locals().values()):
+        raise ValueError(
+            "At least one of these parameters must be provided: "
+            "`lineage-dataset`, `auto-lineage`, `auto-lineage_euk`, "
+            "`auto_lineage-prok`."
+        )


### PR DESCRIPTION
closes #256 

- Adds helper function `_validate_parameters` that raises error with message if parameters lineage_dataset, auto_lineage, auto_lineage_euk and  auto_lineage_prok are all None.