### PR TITLE
FIX: pass the arguments to _process_busco_results in the correct order

### DIFF
--- a/q2_annotate/busco/busco.py
+++ b/q2_annotate/busco/busco.py
@@ -61,7 +61,6 @@ def _busco_helper(mags, common_args, additional_metrics):
 
     if isinstance(mags, MultiMAGSequencesDirFmt):
         sample_dir = mags.sample_dict()
-
     elif isinstance(mags, MAGSequencesDirFmt):
         sample_dir = {"feature_data": mags.feature_dict()}
 
@@ -83,9 +82,10 @@ def _busco_helper(mags, common_args, additional_metrics):
                     os.path.join(str(tmp), sample_id,
                                  os.path.basename(mag_fp), "*.json"))[0]
 
-                results = _process_busco_results(additional_metrics,
-                                                 _extract_json_data(json_path), mag_id,
-                                                 os.path.basename(mag_fp), sample_id)
+                results = _process_busco_results(
+                    _extract_json_data(json_path), sample_id, mag_id,
+                    os.path.basename(mag_fp), additional_metrics
+                )
                 results_all.append(results)
 
     return pd.DataFrame(results_all)

--- a/q2_annotate/busco/tests/test_busco_feature_data.py
+++ b/q2_annotate/busco/tests/test_busco_feature_data.py
@@ -50,12 +50,12 @@ class TestBUSCOFeatureData(TestPluginBase):
             params=['--lineage_dataset', 'bacteria_odb10']
         )
         mock_process.assert_has_calls([
-            call(True, ANY, '24dee6fe-9b84-45bb-8145-de7b092533a1',
-                 '24dee6fe-9b84-45bb-8145-de7b092533a1.fasta', 'feature_data'),
-            call(True, ANY, 'ca7012fc-ba65-40c3-84f5-05aa478a7585',
-                 'ca7012fc-ba65-40c3-84f5-05aa478a7585.fasta', 'feature_data'),
-            call(True, ANY, 'fb0bc871-04f6-486b-a10e-8e0cb66f8de3',
-                 'fb0bc871-04f6-486b-a10e-8e0cb66f8de3.fasta', 'feature_data')
+            call(ANY, 'feature_data', '24dee6fe-9b84-45bb-8145-de7b092533a1',
+                 '24dee6fe-9b84-45bb-8145-de7b092533a1.fasta', True),
+            call(ANY, 'feature_data', 'ca7012fc-ba65-40c3-84f5-05aa478a7585',
+                 'ca7012fc-ba65-40c3-84f5-05aa478a7585.fasta', True),
+            call(ANY, 'feature_data', 'fb0bc871-04f6-486b-a10e-8e0cb66f8de3',
+                 'fb0bc871-04f6-486b-a10e-8e0cb66f8de3.fasta', True)
         ])
 
     @patch(

--- a/q2_annotate/busco/tests/test_busco_sample_data.py
+++ b/q2_annotate/busco/tests/test_busco_sample_data.py
@@ -82,18 +82,18 @@ class TestBUSCOSampleData(TestPluginBase):
         ])
 
         mock_process.assert_has_calls([
-            call(True, ANY, '24dee6fe-9b84-45bb-8145-de7b092533a1',
-                 '24dee6fe-9b84-45bb-8145-de7b092533a1.fasta', 'sample1'),
-            call(True, ANY, 'ca7012fc-ba65-40c3-84f5-05aa478a7585',
-                 'ca7012fc-ba65-40c3-84f5-05aa478a7585.fasta', 'sample1'),
-            call(True, ANY, 'fb0bc871-04f6-486b-a10e-8e0cb66f8de3',
-                 'fb0bc871-04f6-486b-a10e-8e0cb66f8de3.fasta', 'sample1'),
-            call(True, ANY, 'd65a71fa-4279-4588-b937-0747ed5d604d',
-                 'd65a71fa-4279-4588-b937-0747ed5d604d.fasta', 'sample2'),
-            call(True, ANY, 'db03f8b6-28e1-48c5-a47c-9c65f38f7357',
-                 'db03f8b6-28e1-48c5-a47c-9c65f38f7357.fasta', 'sample2'),
-            call(True, ANY, 'fa4d7420-d0a4-455a-b4d7-4fa66e54c9bf',
-                 'fa4d7420-d0a4-455a-b4d7-4fa66e54c9bf.fasta', 'sample2')
+            call(ANY, 'sample1', '24dee6fe-9b84-45bb-8145-de7b092533a1',
+                 '24dee6fe-9b84-45bb-8145-de7b092533a1.fasta', True),
+            call(ANY, 'sample1', 'ca7012fc-ba65-40c3-84f5-05aa478a7585',
+                 'ca7012fc-ba65-40c3-84f5-05aa478a7585.fasta', True),
+            call(ANY, 'sample1', 'fb0bc871-04f6-486b-a10e-8e0cb66f8de3',
+                 'fb0bc871-04f6-486b-a10e-8e0cb66f8de3.fasta', True),
+            call(ANY, 'sample2', 'd65a71fa-4279-4588-b937-0747ed5d604d',
+                 'd65a71fa-4279-4588-b937-0747ed5d604d.fasta', True),
+            call(ANY, 'sample2', 'db03f8b6-28e1-48c5-a47c-9c65f38f7357',
+                 'db03f8b6-28e1-48c5-a47c-9c65f38f7357.fasta', True),
+            call(ANY, 'sample2', 'fa4d7420-d0a4-455a-b4d7-4fa66e54c9bf',
+                 'fa4d7420-d0a4-455a-b4d7-4fa66e54c9bf.fasta', True)
         ])
 
     @patch("q2_annotate.busco.busco._busco_helper")


### PR DESCRIPTION
Closes #263. 