### PR TITLE
MAINT: move BUSCO version pin to distributions

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
   - altair
   - beautifulsoup4
   - bracken
-  - busco >=5.5.0
+  - busco >={{ busco }}
   - diamond
   - eggnog-mapper >=2.1.10
   - gfatools


### PR DESCRIPTION
Depends on https://github.com/qiime2/distributions/pull/823