### PR TITLE
Update broken URL to download DIAMOND database for EggNOG

### DIFF
--- a/q2_annotate/eggnog/dbs.py
+++ b/q2_annotate/eggnog/dbs.py
@@ -131,7 +131,7 @@ def fetch_diamond_db() -> DiamondDatabaseDirFmt:  # type: ignore
             "robots=off",
             "-O",
             f"{path_out}",
-            "http://eggnogdb.embl.de/download/emapperdb-5.0.2/"
+            "http://eggnog5.embl.de/download/emapperdb-5.0.2/"
             "eggnog_proteins.dmnd.gz",
         ]
     )


### PR DESCRIPTION
**Summary:**

This PR address issue #307 by updating the broken URL in q2-annotate used to download the Diamond database for EggNOG.

**Changes Made:**

Replaced the outdated URL, "http://eggnogdb.embl.de/download/emapperdb-5.0.2/", with the new working URL, "http://eggnog5.embl.de/download/emapperdb-5.0.2/".

**Testing:**

Verified that the new URL is accessible and confirmed that q2-annotate successfully downloads the database from the updated source.